### PR TITLE
Added sha to replace -SNAPSHOT in sbt build versions.

### DIFF
--- a/distributed/metadata/src/main/scala/distributed/project/model/Artifacts.scala
+++ b/distributed/metadata/src/main/scala/distributed/project/model/Artifacts.scala
@@ -160,8 +160,10 @@ object BuildArtifacts {
 /** This represents general information every dbuild must know:
  * What artifacts are coming in (from metadta) and where to
  * write new artifacts (so we can save them for later).
+ * 
+ * Also includes the UUID of this build, in case of direct d-build integration.
  */
-case class BuildInput(arts: BuildArtifacts, outRepo: File)
+case class BuildInput(arts: BuildArtifacts, uuid: String, outRepo: File)
 object BuildInput {
   implicit object PrettyPrinter extends ConfigPrint[BuildInput] {
     def apply(r: BuildInput): String = {
@@ -169,6 +171,8 @@ object BuildInput {
       sb append makeMember("artifacts", r.arts)
       sb append ","
       sb append makeMember("outRepo", r.outRepo)
+      sb append ","
+      sb append makeMember("uuid", r.uuid)
       sb append "}"
       sb.toString
     }
@@ -177,11 +181,12 @@ object BuildInput {
     import config._
     val Members = (
       readMember[BuildArtifacts]("artifacts") :^:
-      readMember[java.io.File]("outRepo")
+      readMember[java.io.File]("outRepo") :^:
+      readMember[String]("uuid")
     )
     def unapply(in: ConfigValue): Option[BuildInput] = in match {
-      case Members(artifacts :+: repo :+: HNil) =>
-        Some(BuildInput(artifacts, repo))
+      case Members(artifacts :+: repo :+: uuid :+: HNil) =>
+        Some(BuildInput(artifacts, uuid, repo))
       case _ => None
     }
   }

--- a/distributed/projects/src/main/scala/distributed/project/build/LocalBuildRunner.scala
+++ b/distributed/projects/src/main/scala/distributed/project/build/LocalBuildRunner.scala
@@ -43,7 +43,7 @@ class LocalBuildRunner(builder: BuildRunner,
       // TODO - Load this while resolving!
       val dependencies: BuildArtifacts = BuildArtifacts(artifactLocations, readRepo)
       log.info("Running local build: " + build.config + " in directory: " + dir)
-      val results = builder.runBuild(build, dir, BuildInput(dependencies, writeRepo), log)
+      val results = builder.runBuild(build, dir, BuildInput(dependencies, build.uuid, writeRepo), log)
       // TODO - We pull out just the artifacts published and push them again
       LocalRepoHelper.publishProjectArtiactInfo(build, results.artifacts, writeRepo, repository)
       results

--- a/distributed/support/sbt-plugin/src/main/scala/com/typesafe/dsbt/DistributedRunner.scala
+++ b/distributed/support/sbt-plugin/src/main/scala/com/typesafe/dsbt/DistributedRunner.scala
@@ -154,6 +154,14 @@ object DistributedRunner {
           s.asInstanceOf[Setting[Task[Boolean]]].mapInit((_,old) => old map (_ => true))
         case _ => s
       }
+    case Keys.version.key => 
+      // TODO - Modify version to be unique, not snapshot.
+      s.asInstanceOf[Setting[String]] mapInit { (key, value) =>
+        if(value endsWith "-SNAPSHOT") {
+           
+           value replace ("-SNAPSHOT", "-" + config.info.uuid)
+        } else value
+      } 
     case _ => fixDependencies(config.info.arts.artifacts)(s)
   } 
   

--- a/src/test/scala/ActorMain.scala
+++ b/src/test/scala/ActorMain.scala
@@ -104,7 +104,7 @@ object ActorMain {
         }""").resolve.root)
 
   def communityProjects =
-    Seq(play, akka, scalaStm, specs2, scalacheck, /*scalaIo,*/ scalaConfig, scalaArm, sperformance, specs2scalaz, scalatest)
+    Seq(play, akka, scalaStm, /*specs2,*/ scalacheck, scalaConfig, /*scalaArm, sperformance, specs2scalaz,*/ scalatest)
 
   def sbinary =
     ProjectBuildConfig("sbinary", "sbt", "git://github.com/scala-ide/sbinary.git#plugin_version", sbtWithPerformance)


### PR DESCRIPTION
This makes it so we can export build repositories to IVY caches without fear of polluted artifacts for -SNAPSHOT.   We still have issues if an underlying project uses a _real_ version, but this is the first step towards allowing Akka/Play to run directly against nighttly Scala builds.

Review by @pvlugter / @harrah 
