### PR TITLE
Now we attempt to build play, albeit with failures.

### DIFF
--- a/distributed/support/sbt-plugin/src/main/scala/com/typesafe/dsbt/DistributedRunner.scala
+++ b/distributed/support/sbt-plugin/src/main/scala/com/typesafe/dsbt/DistributedRunner.scala
@@ -14,7 +14,7 @@ object DistributedRunner {
   
   // TODO - Config helper!
   def isValidProject(config: SbtBuildConfig, ref: ProjectRef): Boolean =
-    config.config.projects.isEmpty || (config.config.projects exists ref.project.contains) 
+    config.config.projects.isEmpty || (config.config.projects exists (_ == ref.project))
   
   def timed[A](f: => Stated[A]): Stated[Long] = {
     val start = java.lang.System.currentTimeMillis

--- a/src/test/scala/ActorMain.scala
+++ b/src/test/scala/ActorMain.scala
@@ -101,6 +101,7 @@ object ActorMain {
         config.parseString("""{
           options = [ "-Dplay.version=2.1-SNAPSHOT", "-Dfile.encoding=UTF-8" ]
           projects = [ "Play-Test", "Anorm", "SBT-link", "Templates", "Play", "Root" ]
+          directory = "framework"
         }""").resolve.root)
 
   def communityProjects =


### PR DESCRIPTION
Minor fix to enabled play to build.  Fix was two-fold:
- Missing `directory` setting.
- Logic for string contains was just bad.

Now the build attmepts to compile and you get failures, a step in the right direction.

Review by @pvlugter 
