### PR TITLE
Deserialize SeqString as a Seq, rather than as an array

### DIFF
--- a/distributed/metadata/src/main/scala/distributed/project/model/Config.scala
+++ b/distributed/metadata/src/main/scala/distributed/project/model/Config.scala
@@ -132,7 +132,10 @@ class SeqStringDeserializer extends JsonDeserializer[SeqString] {
     if (generic.isTextual()) {
       SeqString(Seq(valueAs(classOf[String])))
     } else {
-      SeqString(valueAs(classOf[Array[String]]))
+      // The valueAs() returns a WrappedArray; we use
+      // its values to build a new Seq, in order to keep
+      // the same sha1 UUID (a WrappedArray returns a different one)
+      SeqString(Seq(valueAs(classOf[Array[String]]):_*))
     }
   }
 }


### PR DESCRIPTION
The previous deserialization code for SeqString was
implicitly creating a WrappedArray[String], which ends
up having a sha1 UUID that is different from that of
the original Seq (actually a List). Although the code
appeared to work as expected, the differences in
UUID caused drepo to be unable to parse the repository;
dbuild-setup was similarly unable to reload its context.

This commit fixes #54.
