### PR TITLE
Handle more cases for default sbt project names

### DIFF
--- a/distributed/support/sbt-plugin/src/main/scala/com/typesafe/dbuild/DependencyAnalysis.scala
+++ b/distributed/support/sbt-plugin/src/main/scala/com/typesafe/dbuild/DependencyAnalysis.scala
@@ -58,7 +58,8 @@ object DependencyAnalysis {
   //
   def normalizedProjectName(s: ProjectRef, baseDirectory: File) = {
     // we only cover the most common cases. The full logic for 0.13 may involve Load.scala (autoID) and the def default* in Build.scala
-    val defaultIDs = Seq(Build.defaultID(baseDirectory), "root-"+StringUtilities.normalize(baseDirectory.getName))
+    val base=StringUtilities.normalize(baseDirectory.getName)
+    val defaultIDs = Seq(Build.defaultID(baseDirectory), "root-"+base, base)
     val defaultName = "default-sbt-project"
     if (defaultIDs contains s.project) defaultName else s.project
   }


### PR DESCRIPTION
Corrects the inability for dbuild to compile some of the
new Scala modules.
