### PR TITLE
Fix handling of sbt-version

### DIFF
--- a/distributed/metadata/src/main/scala/distributed/project/model/Config.scala
+++ b/distributed/metadata/src/main/scala/distributed/project/model/Config.scala
@@ -304,7 +304,8 @@ case class MavenExtraConfig(
  * sbt-specific build parameters
  */
 case class SbtExtraConfig(
-  @JsonProperty("sbt-version") sbtVersion: String = "", // Note: empty version is interpreted as default, when the Build System extracts this bit
+  // None is interpreted as default: use build.option.sbt-version
+  @JsonProperty("sbt-version") sbtVersion: Option[String] = None,
   directory: String = "",
   @JsonProperty("measure-performance") measurePerformance: Boolean = false,
   @JsonProperty("run-tests") runTests: Boolean = true,
@@ -313,7 +314,7 @@ case class SbtExtraConfig(
   commands: SeqString = Seq.empty,
   projects: SeqString = Seq.empty, // if empty -> build all projects (default)
   exclude: SeqString = Seq.empty // if empty -> exclude no projects (default)
-  ) extends ExtraConfig
+ ) extends ExtraConfig
 
 object BuildSystemExtras {
   val buildSystems: Map[String, java.lang.Class[_ <: ExtraConfig]] = Map(

--- a/distributed/support/default/src/main/scala/distributed/support/sbt/DependencyExtractor.scala
+++ b/distributed/support/default/src/main/scala/distributed/support/sbt/DependencyExtractor.scala
@@ -27,7 +27,7 @@ object SbtExtractor {
       log.debug("Extracting SBT build (" + project + ") dependencies into " + result)
       runner.run(
           projectDir = project,
-          sbtVersion = extra.sbtVersion,
+          sbtVersion = extra.sbtVersion getOrElse sys.error("Internal error: sbtVersion has not been expanded. Please report."),
           log = log,
           javaProps = Map(
               "dbuild.project.dependency.metadata.file" -> result.getAbsolutePath,

--- a/distributed/support/default/src/main/scala/distributed/support/sbt/SbtBuildRunner.scala
+++ b/distributed/support/default/src/main/scala/distributed/support/sbt/SbtBuildRunner.scala
@@ -31,7 +31,7 @@ object SbtBuilder {
       log.debug("Runing SBT build in " + project + " with depsFile " + depsFile)
       runner.run(
         projectDir = project,
-        sbtVersion = config.config.sbtVersion,
+        sbtVersion = config.config.sbtVersion getOrElse sys.error("Internal error: sbtVersion has not been expanded. Please report."),
         log = log,
         javaProps = Map(
             "sbt.repository.config" -> repoFile.getAbsolutePath,

--- a/distributed/support/default/src/main/scala/distributed/support/sbt/SbtBuildSystem.scala
+++ b/distributed/support/default/src/main/scala/distributed/support/sbt/SbtBuildSystem.scala
@@ -19,12 +19,12 @@ class SbtBuildSystem(repos:List[xsbti.Repository], workingDir:File) extends Buil
   final val extractor = new SbtRunner(repos, buildBase / "extractor")
   
   private def sbtExpandConfig(config: ProjectBuildConfig, buildOptions:BuildOptions) = config.extra match {
-    case None => SbtExtraConfig(sbtVersion = Defaults.sbtVersion) // pick default values
+    case None => SbtExtraConfig(sbtVersion = Some(buildOptions.sbtVersion)) // pick default values
     case Some(ec:SbtExtraConfig) => {
-      if (ec.sbtVersion == "")
-        ec.copy(sbtVersion = buildOptions.sbtVersion)
-      else
-        ec
+      ec.sbtVersion match {
+        case None => ec.copy(sbtVersion = Some(buildOptions.sbtVersion))
+        case Some(sbtVer) => ec
+      }
     }
     case _ => throw new Exception("Internal error: sbt build config options are the wrong type in project \""+config.name+"\". Please report")
   }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -87,7 +87,8 @@ object DistributedBuilderBuild extends Build with BuildHelper {
 package distributed.repo.core
 
 object Defaults {
-  val sbtVersion = "%s"
+// no longer used: see sbt-version in Config.scala
+// val sbtVersion = "%s"
   val version = "%s"
   val org = "%s"
 }


### PR DESCRIPTION
If there was no 'extra' section in an sbt-based project,
the version from 'Default.sbtVersion' was being picked up,
rather than the "0.12.4" specified in the documentation.
That was harmless now, but things would have diverged when
building future versions of dbuild using future 0.12.x.

Now picking always the defaults from build.options.sbt-version;
also removed sbtVersion from Defaults.scala, as it is no longer
needed.
