### PR TITLE
Add "deploy-target" Scala options

### DIFF
--- a/distributed/metadata/src/main/scala/distributed/project/model/Config.scala
+++ b/distributed/metadata/src/main/scala/distributed/project/model/Config.scala
@@ -265,6 +265,9 @@ class BuildConfigDeserializer extends JsonDeserializer[ProjectBuildConfig] {
  * build-target:  Overrides the standard ant target that is invoked in order to
  *                generate the artifacts. The default is 'distpack-maven-opt', and it
  *                is not normally changed.
+ * deploy-target: Overrides the ant target that is invoked in order to
+ *                copy the artifacts to a local repository. The default is
+ *                'deploy.local'.
  * build-options: A sequence of additional options that will be passed to ant.
  *                They can specify properties, or modify in some other way the
  *                build. These options will be passed after the ones set by
@@ -274,6 +277,7 @@ class BuildConfigDeserializer extends JsonDeserializer[ProjectBuildConfig] {
 case class ScalaExtraConfig(
   @JsonProperty("build-number") buildNumber: Option[BuildNumber],
   @JsonProperty("build-target") buildTarget: Option[String],
+  @JsonProperty("deploy-target") deployTarget: Option[String],
   @JsonProperty("build-options") buildOptions: SeqString = Seq.empty,
   exclude: SeqString = Seq.empty, // if empty -> exclude no projects (default)
   // 'modules' contains a sequence of sub-projects,

--- a/distributed/support/default/src/main/scala/distributed/support/scala/ScalaBuildSystem.scala
+++ b/distributed/support/default/src/main/scala/distributed/support/scala/ScalaBuildSystem.scala
@@ -26,7 +26,7 @@ object ScalaBuildSystem extends BuildSystemCore {
   val name: String = "scala"
 
   private def scalaExpandConfig(config: ProjectBuildConfig) = config.extra match {
-    case None => ScalaExtraConfig(None, None, Seq.empty, Seq.empty, None) // pick default values
+    case None => ScalaExtraConfig(None, None, None, Seq.empty, Seq.empty, None) // pick default values
     case Some(ec: ScalaExtraConfig) => ec
     case _ => throw new Exception("Internal error: scala build config options are the wrong type in project \"" + config.name + "\". Please report")
   }
@@ -155,7 +155,7 @@ object ScalaBuildSystem extends BuildSystemCore {
     }
 
     val localRepo = input.outRepo
-    Process(Seq("ant", "deploy.local",
+    Process(Seq("ant", ec.deployTarget getOrElse "deploy.local",
       "-Dlocal.snapshot.repository=" + localRepo.getAbsolutePath,
       "-Dlocal.release.repository=" + localRepo.getAbsolutePath,
       "-Dmaven.version.number=" + version) ++ ec.buildOptions, Some(dir / "dists" / "maven" / "latest")) ! log match {

--- a/docs/src/sphinx/dbuild.rst
+++ b/docs/src/sphinx/dbuild.rst
@@ -282,6 +282,7 @@ In the case of Scala, the "extra" record is:
 
    {
     "build-target"   : <build-target>,
+    "deploy-target"  : <deploy-target>,
     "build-options"  : [ opt1, opt2,... ]
     "build-number"   : <build-number>,
     "exclude"        : [ subproj1, subproj2,... ]
@@ -294,6 +295,11 @@ build-target
   The Scala build system will normally generate the files by invoking
   the target "distpack-maven-opt". If required, a different target can
   be specified using this option.
+
+deploy-target
+  This is the ant target that is used to copy the generated files as
+  Maven artifacts, to a local repository. The default is "deploy.local",
+  but it can be overridden by using this option.
 
 build-options
   A sequence of strings; they will be appended to the ant options when


### PR DESCRIPTION
With this option, the standard ant target used
to deploy the Scala files to a local Maven repository
("deploy.local") can be overridden.
