### PR TITLE
Add the "master" configuration to the Ivy build system

### DIFF
--- a/distributed/support/default/src/main/scala/distributed/support/ivy/IvyMachinery.scala
+++ b/distributed/support/default/src/main/scala/distributed/support/ivy/IvyMachinery.scala
@@ -170,7 +170,7 @@ object IvyMachinery {
         case Some("sources") => Seq("sources")
         case Some("javadoc") => Seq("javadoc")
         // if someone asks for the default or compile configs, give them the jar
-        case None if a.getType == "jar" && a.getExt == "jar" => Seq("compile", "default")
+        case None if a.getType == "jar" && a.getExt == "jar" => Seq("master", "compile", "default")
         case _ => Seq("default") // TODO: fetch configs better?
       })).distinct
     }


### PR DESCRIPTION
This is required to compile sbt sources using sbt 0.13.1,
as it requests scala libraries in the "master" configuration
(not needed when using sbt 0.13.0 to compile sbt).
