### PR TITLE
Fix to drepo, improvements

### DIFF
--- a/distributed/build/src/main/scala/distributed/build/SimpleBuildActor.scala
+++ b/distributed/build/src/main/scala/distributed/build/SimpleBuildActor.scala
@@ -165,7 +165,7 @@ class SimpleBuildActor(extractor: ActorRef, builder: ActorRef, repository: Repos
                 val expandedDBuildConfig = DBuildConfiguration(Seq(fullBuild.repeatableBuildConfig), generalOptions)
                 val fullLogger = log.newNestedLogger(expandedDBuildConfig.uuid)
                 writeDependencies(fullBuild, fullLogger)
-                nest(publishFullBuild(expandedDBuildConfig, fullBuild, fullLogger)) { unit =>
+                nest(publishFullBuild(SavedConfiguration(expandedDBuildConfig, fullBuild), fullLogger)) { unit =>
                   // are we building a specific target? If so, filter the graph
                   // are we building a specific target? If so, filter the graph
                   val targetGraph = filterGraph(buildTarget, fullBuild)
@@ -204,15 +204,15 @@ class SimpleBuildActor(extractor: ActorRef, builder: ActorRef, repository: Repos
    * Publishing the full build to the repository and logs the output for
    * re-use.
    */
-  def publishFullBuild(expandedDBuildConfig: DBuildConfiguration, fullBuild: RepeatableDistributedBuild, log: Logger): Unit = {
+  def publishFullBuild(saved: SavedConfiguration, log: Logger): Unit = {
     log.info("---==  Repeatable Build Info ==---")
-    log.info(" uuid = " + fullBuild.uuid)
+    log.info(" uuid = " + saved.uuid)
     log.info("---== Repeatable dbuild Configuration ===---")
     log.info("You can repeat this build (except for -SNAPSHOT references) using this configuration:\n" +
-      Utils.writeValueFormatted(expandedDBuildConfig))
+      Utils.writeValueFormatted(saved.expandedDBuildConfig))
     log.info("---== End Repeatable dbuild Configuration ===---")
     log.info("---== Writing dbuild Metadata ===---")
-    LocalRepoHelper.publishBuildMeta(fullBuild, repository, log)
+    LocalRepoHelper.publishBuildMeta(saved, repository, log)
     log.info("---== End Writing dbuild Metadata ===---")
     log.info("---==  End Repeatable Build Info ==---")
   }

--- a/distributed/metadata/src/main/scala/distributed/project/model/RepeatableBuild.scala
+++ b/distributed/metadata/src/main/scala/distributed/project/model/RepeatableBuild.scala
@@ -124,3 +124,8 @@ case class RepeatableDistributedBuild(builds: Seq[ProjectConfigAndExtracted]) {
     graph.checkCycles()
   }
 }
+
+// This is the structure that is saved in meta/build
+case class SavedConfiguration(expandedDBuildConfig: DBuildConfiguration, fullBuild: RepeatableDistributedBuild) {
+  def uuid = hashing sha1 this
+}

--- a/distributed/repo/src/main/scala/distributed/repo/core/Helper.scala
+++ b/distributed/repo/src/main/scala/distributed/repo/core/Helper.scala
@@ -81,12 +81,12 @@ object LocalRepoHelper {
     }
 
   /** Publishes the given repeatable build configuration to the repository. */
-  def publishBuildMeta(build: RepeatableDistributedBuild, remote: Repository, log: Logger): Unit =
-    publishMeta(build, remote, makeBuildMetaKey, log)
+  def publishBuildMeta(saved: SavedConfiguration, remote: Repository, log: Logger): Unit =
+    publishMeta(saved, remote, makeBuildMetaKey, log)
 
-  def readBuildMeta(uuid: String, remote: ReadableRepository): Option[RepeatableDistributedBuild] = {
+  def readBuildMeta(uuid: String, remote: ReadableRepository): Option[SavedConfiguration] = {
     val file = remote get makeBuildMetaKey(uuid)
-    Some(readValue[RepeatableDistributedBuild](file))
+    Some(readValue[SavedConfiguration](file))
   }
 
   def makeArtifactSha(file: File, localRepo: File) = {

--- a/distributed/repo/src/main/scala/distributed/repo/core/ProjectRepoMain.scala
+++ b/distributed/repo/src/main/scala/distributed/repo/core/ProjectRepoMain.scala
@@ -73,7 +73,7 @@ object ProjectRepoMain {
       val date = new java.util.Date(file.lastModified())
       println("  * " + uuid + " @ " + date)
       val projects = for {
-          build <- LocalRepoHelper.readBuildMeta(uuid, cache).toSeq
+          SavedConfiguration(expandedDBuildConfig, build) <- LocalRepoHelper.readBuildMeta(uuid, cache).toSeq
           project <- build.repeatableBuilds
       } yield (project.config.name, project.uuid)
       val names = padStrings(projects map (_._1))
@@ -174,24 +174,24 @@ object ProjectRepoMain {
   }
   
   def printBuildInfo(uuid: String): Unit = {
-        println("--- RepeatableBuild: " + uuid)
+        println("--- Repeatable Build: " + uuid)
         println(" = Projects = ")
         for {
-          build <- LocalRepoHelper.readBuildMeta(uuid, cache)
+          SavedConfiguration(expandedDBuildConfig, build) <- LocalRepoHelper.readBuildMeta(uuid, cache)
           project <- build.repeatableBuilds
           name = project.config.name
-        } println("  - " + project.uuid + " " + name)
-        println(" = Repeatable Config =")
-        LocalRepoHelper.readBuildMeta(uuid, cache) foreach { build =>
-           println(writeValue(build.repeatableBuildConfig))
-        }    
+        } {
+          println("  - " + project.uuid + " " + name)
+          println(" = Repeatable dbuild configuration =")
+          println(writeValue(expandedDBuildConfig))
+        }
   }
   
   
   def printAllProjectInfo(buildUUID: String): Unit = {
-    println("--- RepeatableBuild: " + buildUUID)
+    println("--- Repeatable Build: " + buildUUID)
     for {
-      build <- LocalRepoHelper.readBuildMeta(buildUUID, cache)
+      SavedConfiguration(expandedDBuildConfig, build) <- LocalRepoHelper.readBuildMeta(buildUUID, cache)
       project <- build.repeatableBuilds
     } try printProjectInfo(project.uuid)
       catch { case _ => println("     " + project.config.name + " is not built.")}

--- a/distributed/support/sbt-plugin/src/main/scala/com/typesafe/dbuild/DistributedRunner.scala
+++ b/distributed/support/sbt-plugin/src/main/scala/com/typesafe/dbuild/DistributedRunner.scala
@@ -15,6 +15,7 @@ import distributed.repo.core.LocalArtifactMissingException
 import org.apache.ivy.core.module.id.ModuleRevisionId
 import distributed.repo.core.LocalRepoHelper
 import distributed.project.model.BuildSubArtifactsOut
+import distributed.project.model.SavedConfiguration
 
 object DistributedRunner {
 
@@ -597,7 +598,7 @@ object DistributedRunner {
     log.info("Finding information for project " + thisProject + " in build " + builduuid)
     val cache = Repository.default
     val projects = (for {
-      build <- LocalRepoHelper.readBuildMeta(builduuid, cache).toSeq
+      SavedConfiguration(expandedDBuildConfig, build) <- LocalRepoHelper.readBuildMeta(builduuid, cache).toSeq
       allProjects = build.repeatableBuilds
       project <- allProjects.filter(_.config.name == thisProject)
     } yield project) // we know project names are unique


### PR DESCRIPTION
Due to previous refactorings, drepo was trying to load from meta/build a structure of an incorrect type. This pull request addresses that issue, and now saves in meta/build both the RepeatableDistributedBuild (aka the Seq[ProjectConfigAndExtracted]), as well as the full (post-processed) DBuildConfiguration, which can be used to reproduce the exact same build.
As a result, drepo can show, given the build uuid, both the build information as well as the full configuration that can be used to restart the same build (including deploy, repositories, cleanup options, etc).
