### PR TITLE
Fix git checkout

### DIFF
--- a/distributed/support/git/src/main/scala/distributed/support/git/Git.scala
+++ b/distributed/support/git/src/main/scala/distributed/support/git/Git.scala
@@ -212,7 +212,7 @@ object GitGit extends GitImplementation {
 
   def checkoutRef(repo: Repo, ref: String, log: Logger): String =
     try {
-      checkout(repo.dir, ref, log)
+      reset(repo.dir, ref, log)
       revparse(repo.dir, "HEAD")
     } catch {
       case t: Exception =>
@@ -223,7 +223,7 @@ object GitGit extends GitImplementation {
   def clean(repo: GitRepo, log: Logger): Unit =
     apply(Seq("clean", "-fdx"), repo.dir, log)
 
-  private def checkout(tempDir: File, branch: String, log: Logger): Unit =
+  private def reset(tempDir: File, branch: String, log: Logger): Unit =
     apply(Seq("reset", "-q", "--hard", branch), tempDir, log)
 
   private def isRemoteBranch(ref: String, cwd: File, log: Logger) =


### PR DESCRIPTION
This pull request addresses an incorrect handling of git checkouts, due to an unexpected interaction between the special refspec that dbuild uses, and "git checkout". Full description in https://github.com/cunei/distributed-build/commit/edd8b505e86b1c1b1e8e391b8c694b153d3abbbd.
As soon as this pull request is merged in, I will release a 0.8.1 hotfix release.
