### PR TITLE
Fix SHAs generation, so that Lists are treated as Traversables

### DIFF
--- a/hashing/src/main/scala/hashing/package.scala
+++ b/hashing/src/main/scala/hashing/package.scala
@@ -18,6 +18,12 @@ package object hashing {
       }
       case bytes: Array[Byte] => md update bytes
       case s: String          => md update s.getBytes
+      case map: Map[String,_] =>
+        val data = map.toSeq.sortBy(_._1)
+        data foreach { case (k,v) =>
+          addBytes(k)
+          addBytes(v)
+        }
       case s: Traversable[_] =>
         // First add a traversable marker..
         md update 1.toByte
@@ -26,12 +32,6 @@ package object hashing {
         // Add a product marker
         md update 5.toByte
         s.productIterator foreach addBytes
-      case map: Map[String,_] =>
-        val data = map.toSeq.sortBy(_._1)
-        data foreach { case (k,v) =>
-          addBytes(k)
-          addBytes(v)
-        }        
       case list: java.util.List[_] =>
         md update 1.toByte
         list.asScala foreach addBytes


### PR DESCRIPTION
This was an interesting bug, which was causing SHAs to change mysteriously across serialization/deserialization.

The "match" for addBytes() has two cases for Traversable and for Product; the case for Product was listed first. However, it just so happens that the default Seq is a List, and therefore the majority of sequences in the system are Lists. And a List is actually a Product, of respectively head and tail.

As a consequence, each time a List was included in a SHA calculation, only the Product case was used. However, when a Seq was the result of some other mapping leading to a WrappedArray, or an ArrayBuffer, the Traversable code path was chosen instead, leading to seemingly inexplicable situations in which working code would no longer work on serialized/deserialized data, which would transform for instance an ArrayBuffer into a List containing the same data.

Just swapping the two case clauses fixes the problem, and allows us to have a stable SHA calculation for all sequences.
