### PR TITLE
Ensure that a locally published dbuild can be found by looking in local ...

### DIFF
--- a/project/packaging.scala
+++ b/project/packaging.scala
@@ -96,9 +96,10 @@ object Packaging {
  directory: ${dbuild.boot.directory-${dbuild.global.base-${user.home}/.dbuild}/boot/}
 
 [ivy]
-  ivy-home: ${user.home}/.dbuild/ivy/
+  ivy-home: ${dbuild.ivy.home-${user.home}/.ivy2/}
   checksums: ${sbt.checksums-sha1,md5}
   override-build-repos: ${sbt.override.build.repos-false}
+  repository-config: ${sbt.repository.config-${sbt.global.base-${user.home}/.sbt}/repositories}
 """ format(sv, name, v, clazz))
     tprops -> ("bin/d"+name+".properties")
   }


### PR DESCRIPTION
...ivy.

Additionally, if local sbt defines a repositories configuration file, use
this to determine which proxy repositories to use.

Review by @cunei 
