### PR TITLE
Bump to sbt 0.13.5 for building (and proxy configuration semantics.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,7 +22,7 @@ object Dependencies {
   //val aether         = "org.sonatype.aether" % "aether" % "1.13.1"
   val mvnAether      = "org.apache.maven" % "maven-aether-provider" % mvnVersion
   val aetherWagon    = "org.sonatype.aether" % "aether-connector-wagon" % "1.13.1"
-  val mvnWagon    = "org.apache.maven.wagon" % "wagon-http" % "2.2"
+  val mvnWagon       = "org.apache.maven.wagon" % "wagon-http" % "2.2"
   val mvnEmbedder    = "org.apache.maven" % "maven-embedder" % mvnVersion
 
   val jacks          = "com.cunei" %% "jacks" % "2.1.9"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,1 @@
-sbt.version=0.12.4
-#sbt.version=0.13.0
+sbt.version=0.13.5


### PR DESCRIPTION
Review by @cunei (at your leisure, just want this in the queue).

I verified that `^publishLocal` still works, and tests still fail in the same place as on master.
