### PR TITLE
Use moduleName rather than name in module info

### DIFF
--- a/plugin/src/main/scala/com/typesafe/dbuild/plugin/DBuildRunner.scala
+++ b/plugin/src/main/scala/com/typesafe/dbuild/plugin/DBuildRunner.scala
@@ -788,6 +788,6 @@ object DBuildRunner {
   def projectSettings: Seq[Setting[_]] = Seq(
     extractArtifacts <<= (Keys.organization, Keys.version, Keys.packagedArtifacts in Compile,
       Keys.crossVersion, Keys.scalaVersion, Keys.scalaBinaryVersion, Keys.sbtBinaryVersion, Keys.sbtPlugin) map extractArtifactLocations,
-    moduleInfo <<= (Keys.organization, Keys.name, Keys.version, Keys.scalaVersion, Keys.scalaBinaryVersion,
+    moduleInfo <<= (Keys.organization, Keys.moduleName, Keys.version, Keys.scalaVersion, Keys.scalaBinaryVersion,
       Keys.sbtVersion, Keys.sbtBinaryVersion, Keys.sbtPlugin, Keys.crossVersion) map generateModuleInfo)
 }


### PR DESCRIPTION
In some projects, the name of the project and the published module name are different. The module name is at least normalized. For example, in Play there are projects like `Play-Java-JDBC` which has a published module name of `play-java-jdbc`.
