### PR TITLE
Add Bintray support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,25 +18,32 @@ To recompile, publish, etc., just type the following in the root project:
 
 where command is one of compile, clean, test, publish, publish-local, etc.
 
-To create a release, point publishTo and credentials to the appropriate
-values, then from the root project type "^release". Please do not use "^publish",
-as some additional preparation is necessary.
+To create a dbuild release (if you belong to the Typesafe organization on Bintray):
 
-The command "^release" will deploy artifacts to the "typesafe/dbuild" Bintray
-repository, but will not issue the release; follow that with a "root/bintrayRelease"
-in order to actually publish the Bintray release. Publishing documentation
-needs to be done separately. If you would like to create a private release
-out of the typesafe organization, you will need to
+1. Type "^release"  (please do not use "^publish", as some additional preparation is necessary)
+2. Check https://bintray.com/typesafe/ivy-releases/dbuild/view to ensure files are as expected (Optional)
+3. Type "root/bintrayRelease" to make the release public
+
+*DO NOT* try to push snapshots to Bintray; instead, add your custom version
+suffix if necessary. The documentation pages on the dbuild website must be
+published separately (but only for final releases).
+
+If you are not part of the Typesafe organization on Bintray, use:
 
   set every bintrayOrganization := None
 
-In order to publish a snapshot, *do not* just issue "^release": snapshots
-should not go to Bintray. Instead, define beforehand:
+to publish to "ivy-releases/dbuild" in your own Bintray repository
+(or to a different repository by changing the settings described
+in the bintray-sbt plugin documentation pages).
+
+If you would like to publish instead to Artifactory, for instance if you
+you need to publish dbuild snapshots, or if you do not have an account on
+Bintray yet, you can use:
 
   set every publishTo := Some(Resolver.url("somelabel", new URL("http://artifactoryhost/artifactory/repository/"))(Resolver.ivyStylePatterns))
   set every credentials := Seq(Credentials(Path.userHome / "some" / "path" / "credentials-file"))
 
-Then, proceed with "^release" as usual to issue the snapshot to some Artifactory instance.
+Then, proceed with "^release" as usual to issue the snapshot to your Artifactory server.
 
 
 ## Get Involved

--- a/README.md
+++ b/README.md
@@ -18,8 +18,25 @@ To recompile, publish, etc., just type the following in the root project:
 
 where command is one of compile, clean, test, publish, publish-local, etc.
 
-To create a full release, point publishTo and credentials to the appropriate
-values, then from the root project type "^release".
+To create a release, point publishTo and credentials to the appropriate
+values, then from the root project type "^release". Please do not use "^publish",
+as some additional preparation is necessary.
+
+The command "^release" will deploy artifacts to the "typesafe/dbuild" Bintray
+repository, but will not issue the release; follow that with a "root/bintrayRelease"
+in order to actually publish the Bintray release. Publishing documentation
+needs to be done separately. If you would like to create a private release
+out of the typesafe organization, you will need to
+
+  set every bintrayOrganization := None
+
+In order to publish a snapshot, *do not* just issue "^release": snapshots
+should not go to Bintray. Instead, define beforehand:
+
+  set every publishTo := Some(Resolver.url("somelabel", new URL("http://artifactoryhost/artifactory/repository/"))(Resolver.ivyStylePatterns))
+  set every credentials := Seq(Credentials(Path.userHome / "some" / "path" / "credentials-file"))
+
+Then, proceed with "^release" as usual to issue the snapshot to some Artifactory instance.
 
 
 ## Get Involved

--- a/build/src/main/scala/com/typesafe/dbuild/build/DeployBuild.scala
+++ b/build/src/main/scala/com/typesafe/dbuild/build/DeployBuild.scala
@@ -65,6 +65,13 @@ class DeployBuild(options: GeneralOptions, log: Logger) extends OptionTask(log) 
               if (loadCreds(credsFile).host != uri.getHost)
                 sys.error("The credentials file " + credsFile + " does not contain information for host " + uri.getHost)
           }
+        case "bintray" =>
+          options.credentials match {
+            case None => sys.error("Credentials are required when deploying to " + uri)
+            case Some(credsFile) =>
+              if (loadCreds(credsFile).host != "api.bintray.com")
+                sys.error("The credentials file " + credsFile + " does not contain information for host api.bintray.com")
+          }
         case scheme => sys.error("Unknown scheme in deploy: " + scheme)
       }
     }

--- a/docs/src/sphinx/deploy.rst
+++ b/docs/src/sphinx/deploy.rst
@@ -63,6 +63,8 @@ repository-uri
     append to the uri the fragment "#release" if you wish a release to be published
     at the end of deploy; if the fragment is not present or is not "#release", the
     artifacts will be left pending in the Bintray repository.
+    The uri format above will work for both generic as well as for Maven-style bintray
+    repositories.
 
 credentials
   A properties file containing at least the properties "host", "user", and "password". The

--- a/docs/src/sphinx/deploy.rst
+++ b/docs/src/sphinx/deploy.rst
@@ -57,12 +57,21 @@ repository-uri
     In order to use key-based authentication, the private key of the system on which
     dbuild runs must be in ``~/.ssh/id_rsa``; the passphrase must be empty.
 
+  ``bintray:/owner/repo/package/version[#release]``
+    The artifacts will be uploaded to Bintray, and optionally released. Exactly four parts
+    must be defined in the path, defining the Bintray parameters. You can optionally
+    append to the uri the fragment "#release" if you wish a release to be published
+    at the end of deploy; if the fragment is not present or is not "#release", the
+    artifacts will be left pending in the Bintray repository.
+
 credentials
   A properties file containing at least the properties "host", "user", and "password". The
   value of the "host" property must match the hostname or the bucket name. In the case of
   Amazon S3, the property "user" contains the Access Key ID, while the property "password"
   contains the Secret Access Key. The credentials specification should be omitted for ``file``
-  repositories.
+  repositories. For Bintray, the "host" must be "api.bintray.com", the Bintray username used
+  as "user", and the Bintray API key must be specified as the password. For Bintray the
+  credentials file may be the standard "/home/user/.bintray/.credentials" file.
 
 projects
   An optional list of project names, from the ones specified in the same build configuration file.

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -233,7 +233,7 @@ trait BuildHelper extends Build {
       settings(
         bintrayReleaseOnPublish := false,
         licenses += ("Apache-2.0", url("http://opensource.org/licenses/Apache-2.0")),
-        bintrayOrganization in bintray := None,
+        bintrayOrganization := Some("typesafe")
         bintrayRepository := "ivy-releases",
         bintrayPackage := "dbuild"
       )

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -10,6 +10,7 @@ import com.typesafe.sbt.site.SphinxSupport
 import com.typesafe.sbt.site.SphinxSupport.{ enableOutput, generatePdf, generatedPdf, generateEpub, generatedEpub, sphinxInputs, sphinxPackages, Sphinx }
 import com.typesafe.sbt.S3Plugin
 import net.virtualvoid.sbt.cross.CrossPlugin
+import bintray.BintrayKeys._
 
 object DBuilderBuild extends Build with BuildHelper {
 
@@ -218,8 +219,6 @@ trait BuildHelper extends Build {
     libraryDependencies += specs2,
     resolvers += Resolver.typesafeIvyRepo("releases"),
     resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/",
-    publishTo <<= isSnapshot { snap => Some(Resolver.url("dbuild-publish-to",
-      new URL("https://private-repo.typesafe.com/typesafe/ivy-" + (if (snap) "snapshots/" else "releases/")))(Resolver.ivyStylePatterns)) },
     publishMavenStyle := false
   )
   /** Create a project. */
@@ -230,6 +229,13 @@ trait BuildHelper extends Build {
       settings(defaultDSettings:_*)
       settings(
         licenses += ("Apache 2", url("http://www.apache.org/licenses/LICENSE-2.0"))
+      )
+      settings(
+        bintrayReleaseOnPublish := false,
+        licenses += ("Apache-2.0", url("http://opensource.org/licenses/Apache-2.0")),
+        bintrayOrganization in bintray := None,
+        bintrayRepository := "ivy-releases",
+        bintrayPackage := "dbuild"
       )
     )
   

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -59,7 +59,7 @@ object DBuilderBuild extends Build with BuildHelper {
     )
   lazy val deploy = (
       Proj("deploy")
-      dependsOnRemote(jacks, jackson, typesafeConfig, commonsLang, aws, uriutil, dispatch, commonsIO,  jsch)
+      dependsOnRemote(jacks, jackson, typesafeConfig, commonsLang, aws, uriutil, dispatch, commonsIO, jsch)
       dependsOnSbt(sbtLogging, sbtIo)
     )
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -233,7 +233,7 @@ trait BuildHelper extends Build {
       settings(
         bintrayReleaseOnPublish := false,
         licenses += ("Apache-2.0", url("http://opensource.org/licenses/Apache-2.0")),
-        bintrayOrganization := Some("typesafe")
+        bintrayOrganization := Some("typesafe"),
         bintrayRepository := "ivy-releases",
         bintrayPackage := "dbuild"
       )

--- a/project/bintray.sbt
+++ b/project/bintray.sbt
@@ -2,7 +2,7 @@
 
 resolvers += Resolver.url("bintray-eed3si9n-sbt-plugins", url("https://dl.bintray.com/eed3si9n/sbt-plugins/"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("com.eed3si9n" % "bintray-sbt" % "0.3.0-93126a5d02f296a4e460e264ecb62b28046aeef1")
+addSbtPlugin("com.eed3si9n" % "bintray-sbt" % "0.3.0-a1934a5457f882053b08cbdab5fd4eb3c2d1285d")
 
 //resolvers += Resolver.url(
 //  "bintray-sbt-plugin-releases",

--- a/project/bintray.sbt
+++ b/project/bintray.sbt
@@ -1,0 +1,13 @@
+// Note: currently using an unofficial pre-release
+
+resolvers += Resolver.url("bintray-eed3si9n-sbt-plugins", url("https://dl.bintray.com/eed3si9n/sbt-plugins/"))(Resolver.ivyStylePatterns)
+
+addSbtPlugin("com.eed3si9n" % "bintray-sbt" % "0.3.0-93126a5d02f296a4e460e264ecb62b28046aeef1")
+
+//resolvers += Resolver.url(
+//  "bintray-sbt-plugin-releases",
+//   url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(
+//       Resolver.ivyStylePatterns)
+//
+//addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.8

--- a/project/packaging.scala
+++ b/project/packaging.scala
@@ -84,8 +84,7 @@ object Packaging {
   maven-central
   sonatype-snapshots: https://oss.sonatype.org/content/repositories/snapshots
   sonatype-releases: https://oss.sonatype.org/content/repositories/releases
-  jcenter-mvn: http://jcenter.bintray.com/
-  jcenter-ivy: http://jcenter.bintray.com/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
+  jcenter: https://jcenter.bintray.com/
   java-annoying-cla-shtuff: http://download.java.net/maven/2/
   typesafe-releases: http://repo.typesafe.com/typesafe/releases
   typesafe-ivy-releases: http://repo.typesafe.com/typesafe/ivy-releases, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]

--- a/project/packaging.scala
+++ b/project/packaging.scala
@@ -84,6 +84,8 @@ object Packaging {
   maven-central
   sonatype-snapshots: https://oss.sonatype.org/content/repositories/snapshots
   sonatype-releases: https://oss.sonatype.org/content/repositories/releases
+  jcenter-mvn: http://jcenter.bintray.com/
+  jcenter-ivy: http://jcenter.bintray.com/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
   java-annoying-cla-shtuff: http://download.java.net/maven/2/
   typesafe-releases: http://repo.typesafe.com/typesafe/releases
   typesafe-ivy-releases: http://repo.typesafe.com/typesafe/ivy-releases, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]


### PR DESCRIPTION
This is for both publishing dbuild to Bintray, as well as deploying dbuild-generated artifacts to Bintray.