### PR TITLE
Ready for 0.9.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # dbuild release notes
 
+### 0.9.4
+
+- Added release notes to the repository
+- Updated default repo list, replacing outdated addresses
+- Clearer message when a test task is unknown
+- Tweaked dependency on	sbt-native-packager, to avoid slf4j issues
+- Added the "null:null" deploy scheme, in order to allow indexes to
+  be generated without having to upload artifacts as well
+- Implemented the "standard" cross-versioning level for the Aether
+  and Assemble build systems
+
 ### 0.9.3
 
 - More checks on the credentials used in Deploy

--- a/build/src/main/scala/com/typesafe/dbuild/build/DeployBuild.scala
+++ b/build/src/main/scala/com/typesafe/dbuild/build/DeployBuild.scala
@@ -56,7 +56,7 @@ class DeployBuild(options: GeneralOptions, log: Logger) extends OptionTask(log) 
     optionsSeq foreach { options =>
       val uri = new _root_.java.net.URI(options.uri)
       uri.getScheme match {
-        case "file" =>
+        case "file" | "null" =>
           if (options.credentials != None) log.warn("Credentials will be ignored while deploying to " + uri)
         case "ssh" | "http" | "https" | "s3" =>
           options.credentials match {

--- a/docs/src/sphinx/conf.py
+++ b/docs/src/sphinx/conf.py
@@ -9,7 +9,7 @@ extensions = ['sphinxcontrib.issuetracker', 'sphinx.ext.extlinks', 'howto']
 
 project = 'dbuild'
 version = '0.9.4'
-release = '0.9.4-SNAPSHOT'
+release = '0.9.4'
 sbt_version = '0.12.4'
 
 # General settings

--- a/docs/src/sphinx/deploy.rst
+++ b/docs/src/sphinx/deploy.rst
@@ -66,6 +66,12 @@ repository-uri
     The uri format above will work for both generic as well as for Maven-style bintray
     repositories.
 
+  ``null:null``
+    The artifacts will be ignored, without actually being uploaded anywhere. This
+    option can be used in conjunction with the index generation facility, described
+    below. By using the ``null:null`` scheme, it is possible to generate an index corresponding
+    to a given subset of artifacts, without having to upload the given artifacts at the same time.
+
 credentials
   A properties file containing at least the properties "host", "user", and "password". The
   value of the "host" property must match the hostname or the bucket name. In the case of

--- a/plugin/src/main/scala/com/typesafe/dbuild/plugin/DBuildRunner.scala
+++ b/plugin/src/main/scala/com/typesafe/dbuild/plugin/DBuildRunner.scala
@@ -468,7 +468,7 @@ object DBuildRunner {
           art.info.name + ". Please report.")
       if (!mavenFile.isFile && !ivyFile.isFile)
         sys.error("Unexpected error: no artifact file found, for the artifact " +
-          art.info.name + ". Please report.")
+          art.info.name + ". We looked for: " + mavenFile.getPath + " and " + ivyFile.getPath + ". Please report.")
       if (mavenFile.isFile)
         retrieveJarFile(mavenFile, scalaHome, name)
       if (ivyFile.isFile)

--- a/plugin/src/main/scala/com/typesafe/dbuild/plugin/DBuildRunner.scala
+++ b/plugin/src/main/scala/com/typesafe/dbuild/plugin/DBuildRunner.scala
@@ -581,7 +581,7 @@ object DBuildRunner {
         // So, we should be safe by crudely casting.
         val taskManifest = ClassManifest.fromClass(classOf[Task[_]]).erasure
         sel match {
-          case None => sys.error("Task not found: " + task)
+          case None => sys.error("You asked dbuild to test using the task \"" + task + "\", but the task is unknown in this project.")
           case Some(key) =>
             // does this AttributeKey refer to a Task ?
             if (key.manifest.erasure == taskManifest) { // select AttributeKey[Task[whatever]]

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -16,7 +16,7 @@ object DBuilderBuild extends Build with BuildHelper {
 
   override def settings = super.settings ++ SbtSupport.buildSettings
 
-  def MyVersion: String = "0.9.4-SNAPSHOT"
+  def MyVersion: String = "0.9.4"
   
   lazy val root = (
     Proj("root") 

--- a/project/native-packaging.sbt
+++ b/project/native-packaging.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "0.7.2")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "0.8.0")


### PR DESCRIPTION
- Added release notes to the repository
- Updated default repo list, replacing outdated addresses
- Clearer message when a test task is unknown
- Tweaked dependency on sbt-native-packager, to avoid slf4j issues
- Added the "null:null" deploy scheme, in order to allow indexes to
  be generated without having to upload artifacts as well
- Implemented the "standard" cross-versioning level for the Aether
  and Assemble build systems